### PR TITLE
Add Server coverage and use mvim for Terminal vim.

### DIFF
--- a/lib/vimrunner/server.rb
+++ b/lib/vimrunner/server.rb
@@ -31,7 +31,11 @@ module Vimrunner
       # the "vim" executable is not compiled with clientserver capabilities,
       # the GUI version is started instead.
       def vim_path
-        'vim'
+        if mac?
+          'mvim'
+        else
+          'vim'
+        end
       end
 
       # The default path to use when starting a server with the GUI version of


### PR DESCRIPTION
By default, MacVim only ships with a single mvim binary which can be used
both to start up a GUI instance and a Terminal instance but only if invoked
via a symlink named "vim". As we only need the Terminal instance to send
remote commands and the default vim that ships with Mac OS X has no
clientserver support, we can depend only on "mvim" for all our needs.

I've also refactored the test suite a little to try and exhaust the different
combinations of GUI, clientserver and platform support.
