### PR TITLE
Add the output to InvalidCommandError exception

### DIFF
--- a/lib/vimrunner/client.rb
+++ b/lib/vimrunner/client.rb
@@ -114,7 +114,7 @@ module Vimrunner
       expression = "VimrunnerEvaluateCommandOutput('#{escape(commands)}')"
 
       server.remote_expr(expression).tap do |output|
-        raise InvalidCommandError if output =~ /^Vim:E\d+:/
+        raise InvalidCommandError.new(output) if output =~ /^Vim:E\d+:/
       end
     end
 


### PR DESCRIPTION
Just a little change to inform the user about what's the problem with a command. I generally add specs to PR but I don't think there is a clean/trivial way to spec this with RSpec. All the current specs are green of course. 
