### PR TITLE
Add feedkeys to more closely simulate user input.

### DIFF
--- a/lib/vimrunner/client.rb
+++ b/lib/vimrunner/client.rb
@@ -114,6 +114,7 @@ module Vimrunner
     #
     # Returns nothing.
     def feedkeys(string)
+      string = string.gsub('"', '\"')
       server.remote_expr(%Q{feedkeys("#{string}")})
     end
 

--- a/spec/vimrunner/client_spec.rb
+++ b/spec/vimrunner/client_spec.rb
@@ -132,6 +132,12 @@ module Vimrunner
         client.write
         File.read('some_file').strip.should eq 'hello'
       end
+
+      it "handles quotes" do
+        client.feedkeys('\<C-R>\'"')
+        client.write
+        File.read('some_file').strip.should eq 'hello\'"'
+      end
     end
 
     describe "#command" do


### PR DESCRIPTION
The current type method uses --remote-send which does not respect
mappings. As a workaround, allow access to feedkeys() which does respect
mappings as if typed by a user.
