### PR TITLE
Fix Path, it should support operators like '+'

### DIFF
--- a/lib/vimrunner/path.rb
+++ b/lib/vimrunner/path.rb
@@ -1,11 +1,12 @@
 module Vimrunner
-  class Path
+  class Path < ::String
     def initialize(path)
-      @path = path
+      super
     end
 
     def to_s
-      @path.to_s.gsub(/([^A-Za-z0-9_\-.,:\/@\n])/, "\\\\\\1")
+      super.to_s.gsub(/([^A-Za-z0-9_\-.,:\/@\n])/, "\\\\\\1")
     end
   end
 end
+


### PR DESCRIPTION
``` shell
> rspec spec/vimrunner/path_spec.rb

Vimrunner::Path
  leaves standard paths untouched
  escapes non-standard characters in paths

Finished in 0.00139 seconds
2 examples, 0 failures
```
