### PR TITLE
Allow setting gvimrc and default to NONE

### DIFF
--- a/lib/vimrunner/server.rb
+++ b/lib/vimrunner/server.rb
@@ -19,7 +19,7 @@ module Vimrunner
     VIMRC        = File.expand_path("../../../vim/vimrc", __FILE__)
     VIMRUNNER_RC = File.expand_path("../../../vim/vimrunner_rc", __FILE__)
 
-    attr_reader :name, :executable, :vimrc
+    attr_reader :name, :executable, :vimrc, :gvimrc
 
     # Public: Initialize a Server
     #
@@ -37,6 +37,7 @@ module Vimrunner
       @executable = options.fetch(:executable) { Platform.vim }
       @name       = options.fetch(:name) { "VIMRUNNER#{rand}" }
       @vimrc      = options.fetch(:vimrc) { VIMRC }
+      @gvimrc     = options.fetch(:gvimrc) { "NONE" }
       @foreground = options.fetch(:foreground, true)
     end
 
@@ -170,7 +171,7 @@ module Vimrunner
 
     def spawn
       PTY.spawn(executable, *%W[
-        #{foreground_option} --servername #{name} -u #{vimrc}
+        #{foreground_option} --servername #{name} -u #{vimrc} -U #{gvimrc}
       ])
     end
 


### PR DESCRIPTION
Hey,

I was writing tests and noticed `~/.gvimrc` was still getting sourced. Passing `-U` to Vim solves this.

I'm terribly sorry for not adding tests, but seeing that you use RSpec, I was afraid to run them because of the [kernel panics](https://github.com/AndrewRadev/vimrunner/issues/29). :)
