### PR TITLE
Fix RSpec dev dependency in gemspec

### DIFF
--- a/vimrunner.gemspec
+++ b/vimrunner.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rdoc'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'rspec', '>= 2.13.0'
+  s.add_development_dependency 'rspec', '~> 2.13.0'
 
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project         = 'vimrunner'


### PR DESCRIPTION
Tests use syntax that is removed or deprecated in RSpec 3.
