### PR TITLE
Remove duplication in Server, fix rescues

### DIFF
--- a/lib/vimrunner/server.rb
+++ b/lib/vimrunner/server.rb
@@ -61,9 +61,7 @@ module Vimrunner
         begin
           @result = yield(connect!)
         ensure
-          @r.close
-          @w.close
-          Process.kill(9, @pid) rescue Errno::ESRCH
+          kill
         end
         @result
       else
@@ -119,7 +117,11 @@ module Vimrunner
     def kill
       @r.close
       @w.close
-      Process.kill(9, @pid) rescue Errno::ESRCH
+
+      begin
+        Process.kill(9, @pid)
+      rescue Errno::ESRCH
+      end
 
       self
     end


### PR DESCRIPTION
`Process.kill(0, @pid) rescue Errno::ESRCH` will rescue all exceptions
(and then return the class Errno::ESRCH). You need a multiline
begin-rescue-end to rescue only a particular exception.
