### PR TITLE
Upgrade to RSpec 3

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
---format d
+--require spec_helper
+--format documentation

--- a/spec/vimrunner/client_spec.rb
+++ b/spec/vimrunner/client_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "vimrunner"
 
 module Vimrunner
-  describe Client do
+  RSpec.describe Client do
     let!(:client) { Vimrunner.start }
 
     after :each do
@@ -11,7 +11,7 @@ module Vimrunner
 
     it "is instantiated in the current directory" do
       cwd = FileUtils.getwd
-      client.command(:pwd).should eq cwd
+      expect(client.command(:pwd)).to eq(cwd)
     end
 
     it "can write a file through Vim" do
@@ -19,15 +19,15 @@ module Vimrunner
       client.insert 'Contents of the file'
       client.write
 
-      File.exists?('some_file').should be_true
-      File.read('some_file').strip.should eq 'Contents of the file'
+      expect(File.exists?('some_file')).to eq(true)
+      expect(File.read('some_file').strip).to eq('Contents of the file')
     end
 
     it "properly escapes filenames" do
       client.edit 'some file'
       client.write
 
-      File.exists?('some file').should be_true
+      expect(File.exists?('some file')).to eq(true)
     end
 
     it "can execute commands with a bang" do
@@ -37,23 +37,23 @@ module Vimrunner
       client.insert 'Contents of the other file'
       client.command :write
 
-      File.exists?('some_file').should be_false
-      File.exists?('some_other_file').should be_true
-      File.read('some_other_file').strip.should eq 'Contents of the other file'
+      expect(File.exists?('some_file')).to eq(false)
+      expect(File.exists?('some_other_file')).to eq(true)
+      expect(File.read('some_other_file').strip).to eq('Contents of the other file')
     end
 
     it "can add a plugin for Vim to use" do
       write_file 'example/plugin/test.vim', 'command Okay echo "OK"'
       client.add_plugin('example', 'plugin/test.vim')
 
-      client.command('Okay').should eq 'OK'
+      expect(client.command('Okay')).to eq('OK')
     end
 
     it "can append a directory to Vim's runtimepath" do
       write_file 'example/test.vim', 'echo "OK"'
       client.append_runtimepath('example')
 
-      client.command('runtime test.vim').should eq 'OK'
+      expect(client.command('runtime test.vim')).to eq('OK')
     end
 
     it "can prepend a directory to Vim's runtimepath, giving it priority" do
@@ -62,33 +62,33 @@ module Vimrunner
       client.append_runtimepath('example_first')
       client.prepend_runtimepath('example_second')
 
-      client.command('runtime test.vim').should eq 'second'
+      expect(client.command('runtime test.vim')).to eq('second')
     end
 
     it "can chain several operations" do
       client.edit('some_file').insert('Contents').write
-      File.exists?('some_file').should be_true
-      File.read('some_file').strip.should eq 'Contents'
+      expect(File.exists?('some_file')).to eq(true)
+      expect(File.read('some_file').strip).to eq('Contents')
     end
 
     describe "#set" do
       it "activates a boolean setting" do
         client.set 'expandtab'
-        client.command('echo &expandtab').should eq '1'
+        expect(client.command('echo &expandtab')).to eq('1')
 
         client.set 'noexpandtab'
-        client.command('echo &expandtab').should eq '0'
+        expect(client.command('echo &expandtab')).to eq('0')
       end
 
       it "sets a setting to a given value" do
         client.set 'tabstop', 3
-        client.command('echo &tabstop').should eq '3'
+        expect(client.command('echo &tabstop')).to eq('3')
       end
 
       it "can be chained" do
         client.set('expandtab').set('tabstop', 3)
-        client.command('echo &expandtab').should eq '1'
-        client.command('echo &tabstop').should eq '3'
+        expect(client.command('echo &expandtab')).to eq('1')
+        expect(client.command('echo &tabstop')).to eq('3')
       end
     end
 
@@ -104,7 +104,7 @@ module Vimrunner
 
         client.write
 
-        File.read('some_file').strip.should eq 'one'
+        expect(File.read('some_file').strip).to eq('one')
       end
 
       it "can be chained" do
@@ -113,18 +113,18 @@ module Vimrunner
 
         client.write
 
-        File.read('some_file').strip.should eq 'two'
+        expect(File.read('some_file').strip).to eq('two')
       end
     end
 
     describe "#echo" do
       it "returns the result of a given expression" do
-        client.echo('"foo"').should eq 'foo'
+        expect(client.echo('"foo"')).to eq('foo')
       end
 
       it "returns the result of multiple expressions" do
         client.command('let b:foo = "bar"')
-        client.echo('"foo"', 'b:foo').should eq 'foo bar'
+        expect(client.echo('"foo"', 'b:foo')).to eq('foo bar')
       end
     end
 
@@ -137,24 +137,24 @@ module Vimrunner
       it "sends keys as if they come from a mapping or user" do
         client.feedkeys('\<C-R>')
         client.write
-        File.read('some_file').strip.should eq 'hello'
+        expect(File.read('some_file').strip).to eq('hello')
       end
 
       it "handles quotes" do
         client.feedkeys('\<C-R>\'"')
         client.write
-        File.read('some_file').strip.should eq 'hello\'"'
+        expect(File.read('some_file').strip).to eq('hello\'"')
       end
     end
 
     describe "#command" do
       it "returns the output of a Vim command" do
-        client.command(:version).should include '+clientserver'
-        client.command('echo "foo"').should eq 'foo'
+        expect(client.command(:version)).to include('+clientserver')
+        expect(client.command('echo "foo"')).to eq('foo')
       end
 
       it "allows single quotes in the command" do
-        client.command("echo 'foo'").should eq 'foo'
+        expect(client.command("echo 'foo'")).to eq('foo')
       end
 
       it "raises an error for a non-existent Vim command" do

--- a/spec/vimrunner/command_spec.rb
+++ b/spec/vimrunner/command_spec.rb
@@ -1,13 +1,13 @@
 require "vimrunner/command"
 
 module Vimrunner
-  describe Command do
+  RSpec.describe Command do
     it "leaves standard commands untouched" do
-      Command.new("set linenumber").to_s.should eq("set linenumber")
+      expect(Command.new("set linenumber").to_s).to eq("set linenumber")
     end
 
     it "escapes single quotes" do
-      Command.new("echo 'foo'").to_s.should eq("echo ''foo''")
+      expect(Command.new("echo 'foo'").to_s).to eq("echo ''foo''")
     end
   end
 end

--- a/spec/vimrunner/errors_spec.rb
+++ b/spec/vimrunner/errors_spec.rb
@@ -3,7 +3,7 @@ require "vimrunner"
 require "vimrunner/errors"
 
 module Vimrunner
-  describe NoSuitableVimError do
+  RSpec.describe NoSuitableVimError do
     it "has a useful message" do
       expect {
         raise NoSuitableVimError

--- a/spec/vimrunner/path_spec.rb
+++ b/spec/vimrunner/path_spec.rb
@@ -1,13 +1,13 @@
 require "vimrunner/path"
 
 module Vimrunner
-  describe Path do
+  RSpec.describe Path do
     it "leaves standard paths untouched" do
-      Path.new("foo.txt").to_s.should eq("foo.txt")
+      expect(Path.new("foo.txt").to_s).to eq("foo.txt")
     end
 
     it "escapes non-standard characters in paths" do
-      Path.new("foo bar!.txt").to_s.should eq('foo\ bar\!.txt')
+      expect(Path.new("foo bar!.txt").to_s).to eq('foo\ bar\!.txt')
     end
   end
 end

--- a/spec/vimrunner/platform_spec.rb
+++ b/spec/vimrunner/platform_spec.rb
@@ -2,23 +2,23 @@ require "spec_helper"
 require "vimrunner/platform"
 
 module Vimrunner
-  describe Platform do
+  RSpec.describe Platform do
     describe "#vim" do
       it "raises an error if no suitable vim could be found" do
-        Platform.stub(:suitable? => false)
+        allow(Platform).to receive(:suitable?).and_return(false)
 
         expect { Platform.vim }.to raise_error(NoSuitableVimError)
       end
 
       it "returns vim if it supports clientserver and xterm_clipboard" do
-        Platform.stub(:features => "+clientserver +xterm_clipboard")
+        allow(Platform).to receive(:features).and_return("+clientserver +xterm_clipboard")
 
-        Platform.vim.should == "vim"
+        expect(Platform.vim).to eq("vim")
       end
 
       it "returns gvim on Linux if vim doesn't support xterm_clipboard" do
-        Platform.stub(:mac? => false)
-        Platform.stub(:features) { |vim|
+        allow(Platform).to receive(:mac?).and_return(false)
+        allow(Platform).to receive(:features) { |vim|
           case vim
           when "vim"
             "+clientserver -xterm_clipboard"
@@ -27,12 +27,12 @@ module Vimrunner
           end
         }
 
-        Platform.vim.should == "gvim"
+        expect(Platform.vim).to eq("gvim")
       end
 
       it "returns mvim on Mac OS X if vim doesn't support clientserver" do
-        Platform.stub(:mac? => true)
-        Platform.stub(:features) { |vim|
+        allow(Platform).to receive(:mac?).and_return(true)
+        allow(Platform).to receive(:features) { |vim|
           case vim
           when "vim"
             "-clientserver -xterm_clipboard"
@@ -41,12 +41,12 @@ module Vimrunner
           end
         }
 
-        Platform.vim.should == "mvim"
+        expect(Platform.vim).to eq("mvim")
       end
 
       it "ignores versions of vim that do not exist on the system" do
-        Platform.stub(:mac? => false)
-        IO.stub(:popen) { |command|
+        allow(Platform).to receive(:mac?).and_return(false)
+        allow(IO).to receive(:popen) { |command|
           if command == ["vim", "--version"]
             raise Errno::ENOENT
           else
@@ -54,28 +54,28 @@ module Vimrunner
           end
         }
 
-        Platform.vim.should == "gvim"
+        expect(Platform.vim).to eq("gvim")
       end
     end
 
     describe "#gvim" do
       it "raises an error if no suitable gvim could be found" do
-        Platform.stub(:suitable? => false)
+        allow(Platform).to receive(:suitable?).and_return(false)
         expect { Platform.gvim }.to raise_error(NoSuitableVimError)
       end
 
       it "returns gvim on Linux" do
-        Platform.stub(:mac? => false)
-        Platform.stub(:features => "+clientserver")
+        allow(Platform).to receive(:mac?).and_return(false)
+        allow(Platform).to receive(:features).and_return("+clientserver")
 
-        Platform.gvim.should == "gvim"
+        expect(Platform.gvim).to eq("gvim")
       end
 
       it "returns mvim on Mac OS X" do
-        Platform.stub(:mac? => true)
-        Platform.stub(:features => "+clientserver")
+        allow(Platform).to receive(:mac?).and_return(true)
+        allow(Platform).to receive(:features).and_return("+clientserver")
 
-        Platform.gvim.should == "mvim"
+        expect(Platform.gvim).to eq("mvim")
       end
     end
   end

--- a/spec/vimrunner/server_spec.rb
+++ b/spec/vimrunner/server_spec.rb
@@ -3,21 +3,21 @@ require "vimrunner/server"
 require "vimrunner/platform"
 
 module Vimrunner
-  describe Server do
+  RSpec.describe Server do
     let(:server) { Server.new }
 
     describe "#initialize" do
       it "defaults to using Platform.vim for the executable" do
-        server.executable.should eq(Platform.vim)
+        expect(server.executable).to eq(Platform.vim)
       end
 
       it "defaults to a random name" do
-        server.name.should start_with("VIMRUNNER")
+        expect(server.name).to start_with("VIMRUNNER")
       end
 
       it "ensures that its server name is uppercase" do
         server = Vimrunner::Server.new(:name => "foo")
-        server.name.should eq("FOO")
+        expect(server.name).to eq("FOO")
       end
     end
 
@@ -25,10 +25,10 @@ module Vimrunner
       it "starts a vim server process" do
         begin
           server.start
-          server.serverlist.should include(server.name)
+          expect(server.serverlist).to include(server.name)
         ensure
           server.kill
-          server.serverlist.should_not include(server.name)
+          expect(server.serverlist).to_not include(server.name)
         end
       end
 
@@ -40,7 +40,7 @@ module Vimrunner
           first.start
           second.start
 
-          first.serverlist.should include(first.name, second.name)
+          expect(first.serverlist).to include(first.name, second.name)
         ensure
           first.kill
           second.kill
@@ -49,10 +49,10 @@ module Vimrunner
 
       it "can start a vim server process with a block" do
         server.start do |client|
-          server.serverlist.should include(server.name)
+          expect(server.serverlist).to include(server.name)
         end
 
-        server.serverlist.should_not include(server.name)
+        expect(server.serverlist).to_not include(server.name)
       end
     end
 
@@ -64,19 +64,19 @@ module Vimrunner
       let(:second_server) { Server.new(:name => server.name) }
 
       it "returns a client" do
-        second_server.connect.should be_a(Client)
-        second_server.connect!.should be_a(Client)
+        expect(second_server.connect).to be_a(Client)
+        expect(second_server.connect!).to be_a(Client)
       end
 
       it "returns a client connected to the named server" do
-        second_server.connect.server.should eq(second_server)
-        second_server.connect!.server.should eq(second_server)
+        expect(second_server.connect.server).to eq(second_server)
+        expect(second_server.connect!.server).to eq(second_server)
       end
 
       describe "#connect" do
         it "returns nil if no server is found in :timeout seconds" do
           server = Server.new(:name => 'NONEXISTENT')
-          server.connect(:timeout => 0.1).should be_nil
+          expect(server.connect(:timeout => 0.1)).to be_nil
         end
       end
 
@@ -93,30 +93,30 @@ module Vimrunner
     describe "#running?" do
       it "returns true if the server started successfully" do
         server.start
-        server.should be_running
+        expect(server).to be_running
       end
 
       it "returns true if the given name corresponds to a running Vim instance" do
         server.start
         other_server = Server.new(:name => server.name)
 
-        other_server.should be_running
+        expect(other_server).to be_running
       end
     end
 
     describe "#new_client" do
       it "returns a client" do
-        server.new_client.should be_a(Client)
+        expect(server.new_client).to be_a(Client)
       end
 
       it "is attached to the server" do
-        server.new_client.server.should == server
+        expect(server.new_client.server).to eq(server)
       end
     end
 
     describe "#remote_expr" do
       it "uses the server's executable to send remote expressions" do
-        server.should_receive(:execute).
+        expect(server).to receive(:execute).
           with([server.executable, "--servername", server.name,
                "--remote-expr", "version"])
 
@@ -126,7 +126,7 @@ module Vimrunner
 
     describe "#remote_send" do
       it "uses the server's executable to send remote keys" do
-        server.should_receive(:execute).
+        expect(server).to receive(:execute).
           with([server.executable, "--servername", server.name,
                "--remote-send", "ihello"])
 
@@ -136,16 +136,16 @@ module Vimrunner
 
     describe "#serverlist" do
       it "uses the server's executable to list servers" do
-        server.should_receive(:execute).
+        expect(server).to receive(:execute).
           with([server.executable, "--serverlist"]).and_return("VIM")
 
         server.serverlist
       end
 
       it "splits the servers into an array" do
-        server.stub(:execute => "VIM\nVIM2")
+        allow(server).to receive(:execute).and_return("VIM\nVIM2")
 
-        server.serverlist.should == ["VIM", "VIM2"]
+        expect(server.serverlist).to eq(["VIM", "VIM2"])
       end
     end
   end

--- a/spec/vimrunner/testing_spec.rb
+++ b/spec/vimrunner/testing_spec.rb
@@ -3,7 +3,7 @@ require 'vimrunner'
 require 'vimrunner/testing'
 
 module Vimrunner
-  describe Testing do
+  RSpec.describe Testing do
     include Testing
 
     specify "#normalize_string_indent" do
@@ -13,7 +13,7 @@ module Vimrunner
         end
       EOF
 
-      sample.should eq "def foo\n  bar\nend"
+      expect(sample).to eq("def foo\n  bar\nend")
     end
 
     specify "#write_file" do
@@ -28,7 +28,7 @@ module Vimrunner
         vim.insert 'def one<cr>  two<cr>end'
         vim.write
 
-        IO.read('written_by_ruby.txt').should eq IO.read('written_by_vim.txt')
+        expect(IO.read('written_by_ruby.txt')).to eq(IO.read('written_by_vim.txt'))
       end
     end
   end

--- a/spec/vimrunner_spec.rb
+++ b/spec/vimrunner_spec.rb
@@ -1,16 +1,16 @@
 require "spec_helper"
 require "vimrunner"
 
-describe Vimrunner do
+RSpec.describe Vimrunner do
   let(:server) { double('server').as_null_object }
 
   describe "#start" do
     before do
-      Vimrunner::Platform.stub(:vim => "vim")
+      allow(Vimrunner::Platform).to receive(:vim).and_return("vim")
     end
 
     it "defaults to using the platform vim" do
-      Vimrunner::Server.should_receive(:new).with(:executable => "vim").
+      expect(Vimrunner::Server).to receive(:new).with(:executable => "vim").
         and_return(server)
 
       Vimrunner.start
@@ -19,11 +19,11 @@ describe Vimrunner do
 
   describe "#start_gvim" do
     before do
-      Vimrunner::Platform.stub(:gvim => "gvim")
+      allow(Vimrunner::Platform).to receive(:gvim).and_return("gvim")
     end
 
     it "defaults to using the platform gvim" do
-      Vimrunner::Server.should_receive(:new).with(:executable => "gvim").
+      expect(Vimrunner::Server).to receive(:new).with(:executable => "gvim").
         and_return(server)
 
       Vimrunner.start_gvim
@@ -39,7 +39,7 @@ describe Vimrunner do
 
     it "connects to an existing server by name" do
       vim = Vimrunner.connect(server.name)
-      vim.server.name.should eq(server.name)
+      expect(vim.server.name).to eq(server.name)
     end
 
     after(:each) do

--- a/vimrunner.gemspec
+++ b/vimrunner.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rdoc'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'rspec', '~> 2.13.0'
+  s.add_development_dependency 'rspec', '~> 3.1.0'
 
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project         = 'vimrunner'


### PR DESCRIPTION
Inspired by @agilecreativity's pull request #37, the major changes are as follows:
- No longer rely on monkey patching by using RSpec.describe
- Use the new expect syntax for assertions
- Use the new expect syntax for mocking and stubbing
