### PR TITLE
Support for native win32 gvim from cygwin ruby

### DIFF
--- a/lib/vimrunner/rspec.rb
+++ b/lib/vimrunner/rspec.rb
@@ -46,11 +46,16 @@ RSpec.configure do |config|
   config.include(Vimrunner::Testing)
 
   # Each example is executed in a separate directory
+  # No trace shall be left in the tmp directory otherwise cygwin won't permit
+  # rmdir => vim is outside the directory at the end
+  # TODO: ensure a cd(pwd) à la RAII
+  pwd = Dir.pwd
   config.around(:each) do |example|
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
-        vim.command("cd #{dir}")
+        vim.cd(dir)
         example.run
+        vim.cd(pwd)
       end
     end
   end

--- a/lib/vimrunner/server.rb
+++ b/lib/vimrunner/server.rb
@@ -138,7 +138,7 @@ module Vimrunner
     #
     # Returns an Array of String server names currently running.
     def serverlist
-      execute([executable, "--serverlist"]).split("\n")
+      execute([executable, "--serverlist"]).split(/\r?\n/)
     end
 
     # Public: Evaluates an expression in the Vim server and returns the result.
@@ -172,8 +172,9 @@ module Vimrunner
     end
 
     def spawn
-      PTY.spawn(executable, *%W[
-        #{foreground_option} --servername #{name} -u #{vimrc} -U #{gvimrc}
+      the_exec = Platform.spawn_executable
+      PTY.spawn(the_exec, *%W[
+        #{foreground_option} --servername #{name} -u #{Platform.fix_path vimrc} -U #{gvimrc}
       ])
     end
 

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -7,5 +7,7 @@ syntax on
 set noswapfile nobackup
 
 " remove default ~/.vim directories to avoid loading plugins
+set runtimepath-=~/vimfiles
+set runtimepath-=~/vimfiles/after
 set runtimepath-=~/.vim
 set runtimepath-=~/.vim/after


### PR DESCRIPTION
This patch is a first draft toward the resolution of RfC #32.

The following modifications were required:

 - In vimrc, ~/.vim becomes ~/vimfiles under Windows

 - The win32 gvim version won't display anything to the console. Even when
   called with --version, --remote*, ou --server*
   All commands need to be send with plain "vim" (the version I have cannot do
   anything else than sending commands to a vim server)
   And the spawn has to be gvim -- don't ask me why
   (of course, both have to be in the PATH)
   Hence the new functions `spawn_executable()` and `windows?()`

 - When ruby comes from cygwin distribution, and when gvim version is the
   native one, paths need to be fixed with cygpath executable.
   In order to ease its use, I've encapsulated its calls from Client methods, and
   provide some new function like `Client.cd` and `Platform.fix_path`

 - I've also added `Client.runtime`.

 - When using `feedkeys` to `:source` a script, the call seems to be
   asynchronous.
   Vim doesn't wait and the next command is sent much to early.
   I've changed the call to source to use --remote-send. May be we need a
   special version that simply injects vimrunner_rc.

 - When we request to rmdir vim current directory (set with `:cd`),
   cygwin-ruby Dir.mktmpdir finalizer fails. Vim needs to be set back into a
   neutral directory that we won't try to remove.

 - New lines may contain a \r before the \n on windows.

The following issues are still pending:

 - The cygwin version of gvim distributed with cygwin package manager doesn't
   support +clientserver.
   As such, I didn't tried this version

 - I suspect that start/start_gvim only concern the spawn. In order to
   send remote commands, `vim` is always enough -- no need for `gvim` (but I
   don't know regarding `mvim`)
   It may be possible to simplify the codebase.

 - As my ruby version comes from cygwin distribution, I haven't tested native
   win32/64 versions of ruby, nor other shells mingw, ...

 - It'd certainly be best to merge vimrunner_rc code into the vimrc. Why two
   files? It causes troubles:
    - feedkeys is used to implement `Client.source` as `Client.command` relies
      on a function from vimrunner_rc

 - I still have errors I cannot explain with UTF-8. I'm not sure where they
   come from. May be vim-client knows how to solve them.
   https://www.omniref.com/ruby/gems/vim_client-ruby/0.1.0/symbols/VimClient