### PR TITLE
Add more possible automatically-found vim executables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: ruby
 rvm:
   - 1.9.3
-before_install: sudo apt-get install vim-gtk
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y vim-gtk
+  - gem install bundler -v '~> 1.11'
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ meaning one of the following:
 
 * `vim` if it supports headlessly creating servers (see [Requirements](#requirements) below for more information);
 * `gvim`;
-* `mvim -v` (headless), or `mvim` if you are on Mac OS X.
+* `mvim -v` (headless), or `mvim` if you are on Mac OS X;
+* `alias vim` specified in your `~/.profile`, `~/.bash_profile`, or `~/.bashrc` (headless, or not).
 
 If you wish to always start a GUI Vim (viz. skip using a headless `vim`) then
 you can use `start_gvim` like so:

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Vimrunner will attempt to start up the most suitable version of Vim available,
 meaning one of the following:
 
 * `vim` if it supports headlessly creating servers (see [Requirements](#requirements) below for more information);
-* `mvim` if you are on Mac OS X;
-* `gvim`.
+* `gvim`;
+* `mvim -v` (headless), or `mvim` if you are on Mac OS X.
 
 If you wish to always start a GUI Vim (viz. skip using a headless `vim`) then
 you can use `start_gvim` like so:

--- a/lib/vimrunner/platform.rb
+++ b/lib/vimrunner/platform.rb
@@ -45,7 +45,19 @@ module Vimrunner
         ["vim", "mvim -v", "mvim", "gvim"]
       else
         ["vim", "gvim"]
-      end
+      end + shell_aliases
+    end
+
+    def shell_aliases
+      [shell_vim_alias, shell_vim_alias_without_args]
+    end
+
+    def shell_vim_alias
+      `source ~/.profile; source ~/.bash_profile; source ~/.bashrc; alias vim`[/'(.+)'/, 1]
+    end
+
+    def shell_vim_alias_without_args
+      shell_vim_alias && shell_vim_alias[/^[^ ]+/]
     end
 
     def suitable?(vim)
@@ -59,9 +71,11 @@ module Vimrunner
     end
 
     def gui?(vim)
-      executable = File.basename(vim)
+      if vim
+        executable = File.basename(vim)
 
-      gvim_or_mvim_without_shell_switch?(executable)
+        gvim_or_mvim_without_shell_switch?(executable)
+      end
     end
 
     def gvim_or_mvim_without_shell_switch?(executable)

--- a/lib/vimrunner/platform.rb
+++ b/lib/vimrunner/platform.rb
@@ -37,15 +37,15 @@ module Vimrunner
     private
 
     def gvims
-      if mac?
-        %w( mvim gvim )
-      else
-        %w( gvim )
-      end
+      vims.select { |v| gui?(v) }
     end
 
     def vims
-      %w( vim ) + gvims
+      if mac?
+        ["vim", "mvim -v", "mvim", "gvim"]
+      else
+        ["vim", "gvim"]
+      end
     end
 
     def suitable?(vim)
@@ -61,11 +61,17 @@ module Vimrunner
     def gui?(vim)
       executable = File.basename(vim)
 
-      executable[0, 1] == "g" || executable[0, 1] == "m"
+      gvim_or_mvim_without_shell_switch?(executable)
+    end
+
+    def gvim_or_mvim_without_shell_switch?(executable)
+      executable.include?("gvim") || (
+        executable.include?("mvim") && executable !~ / -v\b/
+      )
     end
 
     def features(vim)
-      IO.popen([vim, "--version"]) { |io| io.read.strip }
+      `#{vim} --version` || ""
     rescue Errno::ENOENT
       ""
     end

--- a/spec/vimrunner/platform_spec.rb
+++ b/spec/vimrunner/platform_spec.rb
@@ -18,41 +18,53 @@ module Vimrunner
 
       it "returns gvim on Linux if vim doesn't support xterm_clipboard" do
         allow(Platform).to receive(:mac?).and_return(false)
-        allow(Platform).to receive(:features) { |vim|
+        allow(Platform).to receive(:features) do |vim|
           case vim
           when "vim"
             "+clientserver -xterm_clipboard"
-          when "gvim"
-            "+clientserver"
+          else
+            "+clientserver +xterm_clipboard"
           end
-        }
+        end
 
         expect(Platform.vim).to eq("gvim")
       end
 
-      it "returns mvim on Mac OS X if vim doesn't support clientserver" do
+      it "returns mvim on Mac OS X if console vims don't support clientserver" do
         allow(Platform).to receive(:mac?).and_return(true)
-        allow(Platform).to receive(:features) { |vim|
-          case vim
-          when "vim"
-            "-clientserver -xterm_clipboard"
-          when "mvim"
+        allow(Platform).to receive(:features) do |vim|
+          if vim == 'mvim'
             "+clientserver -xterm_clipboard"
+          else
+            "-clientserver -xterm_clipboard"
           end
-        }
+        end
 
         expect(Platform.vim).to eq("mvim")
       end
 
+      it "returns console mvim on Mac OS X if it supports what vim doesn't" do
+        allow(Platform).to receive(:mac?).and_return(true)
+        allow(Platform).to receive(:features) do |vim|
+          if vim == 'mvim -v'
+            "+clientserver +xterm_clipboard"
+          else
+            "+clientserver -xterm_clipboard"
+          end
+        end
+
+        expect(Platform.vim).to eq("mvim -v")
+      end
+
       it "ignores versions of vim that do not exist on the system" do
         allow(Platform).to receive(:mac?).and_return(false)
-        allow(IO).to receive(:popen) { |command|
+        allow(Platform).to receive(:`) do |command|
           if command == ["vim", "--version"]
             raise Errno::ENOENT
           else
             "+clientserver"
           end
-        }
+        end
 
         expect(Platform.vim).to eq("gvim")
       end
@@ -60,20 +72,25 @@ module Vimrunner
 
     describe "#gvim" do
       it "raises an error if no suitable gvim could be found" do
-        allow(Platform).to receive(:suitable?).and_return(false)
+        allow(Platform).to receive(:suitable?) do |vim|
+          ['vim', 'mvim -v'].include?(vim)
+        end
+
         expect { Platform.gvim }.to raise_error(NoSuitableVimError)
       end
 
       it "returns gvim on Linux" do
         allow(Platform).to receive(:mac?).and_return(false)
-        allow(Platform).to receive(:features).and_return("+clientserver")
+        allow(Platform).to receive(:features).
+          and_return("+clientserver +xterm_clipboard")
 
         expect(Platform.gvim).to eq("gvim")
       end
 
       it "returns mvim on Mac OS X" do
         allow(Platform).to receive(:mac?).and_return(true)
-        allow(Platform).to receive(:features).and_return("+clientserver")
+        allow(Platform).to receive(:features).
+          and_return("+clientserver +xterm_clipboard")
 
         expect(Platform.gvim).to eq("mvim")
       end

--- a/spec/vimrunner/platform_spec.rb
+++ b/spec/vimrunner/platform_spec.rb
@@ -3,6 +3,9 @@ require "vimrunner/platform"
 
 module Vimrunner
   RSpec.describe Platform do
+    let(:vim_alias) { "/Applications/mvim -v" }
+    let(:gvim_alias) { "/Applications/mvim" }
+
     describe "#vim" do
       it "raises an error if no suitable vim could be found" do
         allow(Platform).to receive(:suitable?).and_return(false)
@@ -33,7 +36,7 @@ module Vimrunner
       it "returns mvim on Mac OS X if console vims don't support clientserver" do
         allow(Platform).to receive(:mac?).and_return(true)
         allow(Platform).to receive(:features) do |vim|
-          if vim == 'mvim'
+          if vim == "mvim"
             "+clientserver -xterm_clipboard"
           else
             "-clientserver -xterm_clipboard"
@@ -46,7 +49,7 @@ module Vimrunner
       it "returns console mvim on Mac OS X if it supports what vim doesn't" do
         allow(Platform).to receive(:mac?).and_return(true)
         allow(Platform).to receive(:features) do |vim|
-          if vim == 'mvim -v'
+          if vim == "mvim -v"
             "+clientserver +xterm_clipboard"
           else
             "+clientserver -xterm_clipboard"
@@ -68,12 +71,36 @@ module Vimrunner
 
         expect(Platform.vim).to eq("gvim")
       end
+
+      context 'with aliases' do
+        before do
+          allow(Platform).to receive(:`).with(
+            "source ~/.profile; source ~/.bash_profile; source ~/.bashrc; alias vim"
+          ).and_return("alias vim='#{vim_alias}'")
+        end
+
+        it "returns vim alias if normal executables aren't suitable" do
+          allow(Platform).to receive(:suitable?) do |vim|
+            !["vim", "mvim -v", "mvim", "gvim"].include?(vim)
+          end
+
+          expect(Platform.vim).to eq(vim_alias)
+        end
+
+        it "return gvim alias if even vim alias is not suitable" do
+          allow(Platform).to receive(:suitable?) do |vim|
+            !["vim", "mvim -v", "mvim", "gvim", vim_alias].include?(vim)
+          end
+
+          expect(Platform.vim).to eq(gvim_alias)
+        end
+      end
     end
 
     describe "#gvim" do
-      it "raises an error if no suitable gvim could be found" do
+      it "raises an error if only console vims are suitable" do
         allow(Platform).to receive(:suitable?) do |vim|
-          ['vim', 'mvim -v'].include?(vim)
+          ["vim", "mvim -v"].include?(vim)
         end
 
         expect { Platform.gvim }.to raise_error(NoSuitableVimError)
@@ -93,6 +120,22 @@ module Vimrunner
           and_return("+clientserver +xterm_clipboard")
 
         expect(Platform.gvim).to eq("mvim")
+      end
+
+      context 'with aliases' do
+        before do
+          allow(Platform).to receive(:`).with(
+            "source ~/.profile; source ~/.bash_profile; source ~/.bashrc; alias vim"
+          ).and_return("alias vim='#{vim_alias}'")
+        end
+
+        it "returns gvim alias if nothing else works" do
+          allow(Platform).to receive(:suitable?) do |vim|
+            !["gvim", "mvim"].include?(vim)
+          end
+
+          expect(Platform.gvim).to eq(gvim_alias)
+        end
       end
     end
   end


### PR DESCRIPTION
Now `mvim -v`, and your `alias vim` vims, either headless, or not, should be found automatically as possible executables hopefully saving someone's time. It helps when you're using El Capitan, compiled vim by yourself, and resorted to simply adding an alias to shadow the system-wide vim.
