### PR TITLE
add Vimrunner::Server.pid

### DIFF
--- a/lib/vimrunner/server.rb
+++ b/lib/vimrunner/server.rb
@@ -19,7 +19,7 @@ module Vimrunner
     VIMRC        = File.expand_path("../../../vim/vimrc", __FILE__)
     VIMRUNNER_RC = File.expand_path("../../../vim/vimrunner_rc", __FILE__)
 
-    attr_reader :name, :executable, :vimrc, :gvimrc
+    attr_reader :name, :executable, :vimrc, :gvimrc, :pid
 
     # Public: Initialize a Server
     #

--- a/spec/vimrunner/server_spec.rb
+++ b/spec/vimrunner/server_spec.rb
@@ -148,5 +148,12 @@ module Vimrunner
         expect(server.serverlist).to eq(["VIM", "VIM2"])
       end
     end
+
+    describe "pid" do
+      it "returns the pid of the server" do
+        server.start
+        expect(server.pid).not_to be(nil)
+      end
+    end
   end
 end


### PR DESCRIPTION
In [vim-elixir](https://github.com/elixir-lang/vim-elixir/blob/master/bin/spawn_vim) I'd like to `Process.wait(vim.server.pid)`. Right now without waiting the MacVim instance closes immediately. My other options are to `instance_eval` or `loop {}` neither of which is very good. @AndrewRadev how would you feel about exposing the pid?