### PR TITLE
Relax RSpec dependency to fix CI build

### DIFF
--- a/vimrunner.gemspec
+++ b/vimrunner.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rdoc'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'rspec', '~> 3.1.0'
+  s.add_development_dependency 'rspec', '~> 3.5'
 
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project         = 'vimrunner'


### PR DESCRIPTION
As we don't specify a version of Rake, builds are now breaking due to the removal of last_comment in Rake 11 and its usage in our outdated version of RSpec.

We could fix this by specifying a version constraint for all development dependencies but we can also relax our constraint on RSpec so that we pull in a more recent version without this bug.