### PR TITLE
Add `-i NONE --noplugin` to Vim command-line options

### DIFF
--- a/lib/vimrunner/server.rb
+++ b/lib/vimrunner/server.rb
@@ -173,7 +173,12 @@ module Vimrunner
 
     def spawn
       PTY.spawn(executable, *%W[
-        #{foreground_option} --servername #{name} -u #{vimrc} -U #{gvimrc}
+        #{foreground_option}
+        --servername #{name}
+        -u #{vimrc}
+        -U #{gvimrc}
+        -i NONE
+        --noplugin
       ])
     end
 


### PR DESCRIPTION
Based on a suggestion in #49, I've added these two options to the `spawn` method. 

The `-i NONE` removes logging to `.viminfo`, which seems like a safe thing to add. The `--noplugin` option disables any loading of plugins upon load. I'm a bit nervous about that one, but it doesn't seem to block usage of `add_plugin`, which manually `runtime`-s plugins anyway. So, it shouldn't be a problem either.

Since we already load our own `vimrc`, I feel like there's no additional problem to also disable plugins. There's the manual `connect` call, which would allow people to spawn their own Vim, if they want their full set of plugins and settings.

I'll leave this PR open for a week or so for any comments and suggestions.