### PR TITLE
Server.kill: use :quitall

### DIFF
--- a/lib/vimrunner/server.rb
+++ b/lib/vimrunner/server.rb
@@ -115,13 +115,21 @@ module Vimrunner
     #
     # Returns self.
     def kill
-      @r.close
-      @w.close
+      remote_send("<C-\\><C-n>:quitall!<CR>")
 
       begin
-        Process.kill(9, @pid)
-      rescue Errno::ESRCH
+        Timeout.timeout(3, TimeoutError) do
+          sleep 0.1 while Process.waitpid(@pid, Process::WNOHANG).nil?
+        end
+      rescue TimeoutError
+        begin
+          Process.kill("TERM", @pid)
+        rescue Errno::ESRCH
+        end
       end
+
+      @r.close
+      @w.close
 
       self
     end


### PR DESCRIPTION
The previous method of closing input/output unconditionally will cause
Vim to end with SIGHUP, which causes a wrapping process using Python's
`subprocess` module to abort:

    10342      0.000166 write(1, "Vim: Finished.\r\n", 16) = -1 EIO (Input/output error)
    10342      0.000169 rt_sigaction(SIGHUP, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7ff4714958f0}, {sa_handler=SIG_IGN, sa_mask=[HUP], sa_flags=SA_RESTORER|SA_REST>
    10342      0.000122 rt_sigprocmask(SIG_UNBLOCK, [HUP], [HUP], 8) = 0
    10342      0.000081 getpid()            = 10342
    10342      0.000058 kill(10342, SIGHUP) = 0
    10342      0.000103 --- SIGHUP {si_signo=SIGHUP, si_code=SI_USER, si_pid=10342, si_uid=1000} ---

Using `:quitall!` and waiting for Vim to finish is cleaner.

This also uses SIGTERM instead of SIGKILL.

Fixes https://github.com/AndrewRadev/vimrunner/issues/51.