### PR TITLE
Also ignore vim directories in ~/.config

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -8,4 +8,6 @@ set noswapfile nobackup
 
 " remove default ~/.vim directories to avoid loading plugins
 set runtimepath-=~/.vim
+set runtimepath-=~/.config/vim
 set runtimepath-=~/.vim/after
+set runtimepath-=~/.config/vim/after


### PR DESCRIPTION
Following this, I have my vim directory at `~/.config/vim`: https://github.com/vim/vim/commit/c9df1fb35a1866901c32df37dd39c8b39dbdb64a

This caused me some issues running the tests in https://github.com/vim-ruby/vim-ruby.

I wanted to fully support the `XDG_CONFIG_HOME` environment variable too but I don't have enough Vim script skills unfortunately.